### PR TITLE
COV-6 Update easy read to refer to autumn boosters

### DIFF
--- a/app/landing/views.py
+++ b/app/landing/views.py
@@ -47,6 +47,7 @@ metrics = [
     'cumPeopleVaccinatedFirstDoseByPublishDate',
     'cumPeopleVaccinatedSecondDoseByPublishDate',
     'cumPeopleVaccinatedThirdInjectionByPublishDate',
+    'cumPeopleVaccinatedAutumn22ByVaccinationDate50+',
 
     'newDailyNsoDeathsByDeathDateChange',
     'newDailyNsoDeathsByDeathDateRollingSum',

--- a/app/postcode/assets/query_params.json
+++ b/app/postcode/assets/query_params.json
@@ -20,6 +20,7 @@
       "cumPeopleVaccinatedFirstDoseByPublishDate",
       "cumPeopleVaccinatedSecondDoseByPublishDate",
       "cumPeopleVaccinatedThirdInjectionByPublishDate",
+      "cumPeopleVaccinatedAutumn22ByVaccinationDate50+",
       "newDailyNsoDeathsByDeathDateChange",
       "newDailyNsoDeathsByDeathDateRollingSum",
       "newDailyNsoDeathsByDeathDateChangePercentage",

--- a/app/templates/html/components/easy_read/vaccinations.html
+++ b/app/templates/html/components/easy_read/vaccinations.html
@@ -1,6 +1,7 @@
 {% set first = ("cumPeopleVaccinatedFirstDoseByPublishDate" | get_data(data)) %}
 {% set second = ("cumPeopleVaccinatedSecondDoseByPublishDate" | get_data(data)) %}
 {% set third = ("cumPeopleVaccinatedThirdInjectionByPublishDate" | get_data(data)) %}
+{% set booster = ("cumPeopleVaccinatedAutumn22ByVaccinationDate50+" | get_data(data)) %}
 
 <h3 id="vaccinations">Vaccinations{% if first.areaName != "United Kingdom" %} in {{ first.areaName }}{% endif %}</h3>
 
@@ -18,4 +19,8 @@
 
 <p>
 	<b>{{ third.value }}</b> people had been given a booster or third dose by the end of {{ third.date }}.
+</p>
+
+<p>
+	<b>{{ booster.value }}</b> people had been given an autumn booster by the end of {{ booster.date }}.
 </p>

--- a/app/templates/latex/sections/vaccinations.tex
+++ b/app/templates/latex/sections/vaccinations.tex
@@ -1,6 +1,7 @@
 {% set first = ("cumPeopleVaccinatedFirstDoseByPublishDate" | get_data(data)) %}
 {% set second = ("cumPeopleVaccinatedSecondDoseByPublishDate" | get_data(data)) %}
 {% set third = ("cumPeopleVaccinatedThirdInjectionByPublishDate" | get_data(data)) %}
+{% set booster = ("cumPeopleVaccinatedAutumn22ByVaccinationDate50+" | get_data(data)) %}
 
 \section{Vaccinations{% if first.areaName != "United Kingdom" %} in {{ first.areaName | trim_area_name }}{% endif %} }
 
@@ -11,3 +12,5 @@ Vaccines are given in several doses.
 {\bf {{ second.value }}} people had been given a second dose by the end of {{ second.date }}.
 
 {\bf {{ third.value }}} people had been given a booster or third dose by the end of {{ third.date }}.
+
+{\bf {{ booster.value }}} people had been given an autumn booster by the end of {{ booster.date }}.


### PR DESCRIPTION
Changes made:
- Added `cumPeopleVaccinatedAutumn22ByVaccinationDate50+` metric to the list of them,
- Modified templates (added 4th line with autumn boosters).
